### PR TITLE
Fix ECSD CmdArg initialization

### DIFF
--- a/Pi3BoardPkg/Drivers/MmcDxe/MmcBlockIo.c
+++ b/Pi3BoardPkg/Drivers/MmcDxe/MmcBlockIo.c
@@ -514,7 +514,7 @@ EFI_STATUS InitializeMmcDevice(
 
     if (MmcHostInstance->CardInfo.CardType == MMC_CARD) {
         // Fetch ECSD
-        CmdArg = MmcHostInstance->CardInfo.RCA << 16;
+        CmdArg = 0;
         Status = MmcHost->SendCommand(MmcHost, MMC_CMD8, CmdArg);
         if (EFI_ERROR(Status)) {
             DEBUG((EFI_D_ERROR, "MmcDxe: InitializeMmcDevice(): ECSD fetch error, Status=%r.\n", Status));

--- a/Pi3BoardPkg/Drivers/MmcDxe/MmcBlockIo.c
+++ b/Pi3BoardPkg/Drivers/MmcDxe/MmcBlockIo.c
@@ -445,7 +445,7 @@ EFI_STATUS InitializeMmcDevice(
     EFI_MMC_HOST_PROTOCOL   *MmcHost;
     UINT32                  BlockCount;
     UINT32                  ECSD[128];
-
+    
 #if MMC_COLLECT_STATISTICS
     UINT64                  InitializationStartTime = GetPerformanceCounter();
 #endif // MMC_COLLECT_STATISTICS

--- a/Pi3BoardPkg/Drivers/MmcDxe/MmcBlockIo.c
+++ b/Pi3BoardPkg/Drivers/MmcDxe/MmcBlockIo.c
@@ -445,7 +445,7 @@ EFI_STATUS InitializeMmcDevice(
     EFI_MMC_HOST_PROTOCOL   *MmcHost;
     UINT32                  BlockCount;
     UINT32                  ECSD[128];
-    
+
 #if MMC_COLLECT_STATISTICS
     UINT64                  InitializationStartTime = GetPerformanceCounter();
 #endif // MMC_COLLECT_STATISTICS
@@ -514,6 +514,7 @@ EFI_STATUS InitializeMmcDevice(
 
     if (MmcHostInstance->CardInfo.CardType == MMC_CARD) {
         // Fetch ECSD
+        CmdArg = MmcHostInstance->CardInfo.RCA << 16;
         Status = MmcHost->SendCommand(MmcHost, MMC_CMD8, CmdArg);
         if (EFI_ERROR(Status)) {
             DEBUG((EFI_D_ERROR, "MmcDxe: InitializeMmcDevice(): ECSD fetch error, Status=%r.\n", Status));


### PR DESCRIPTION
Release builds failed to compile due to a possible uninitialized
variable in MmcDxe. Turns out the ECSD CmdArg was never
initialized to the proper RCA value. This patch fixes ECSD CmdArg.

Signed-off-by: Christopher Co <christopher.co@microsoft.com>