### PR TITLE
Fix system crash for low-resolution display configurations:

### DIFF
--- a/Pi2BoardPkg/Drivers/DisplayDxe/DisplayDxe.c
+++ b/Pi2BoardPkg/Drivers/DisplayDxe/DisplayDxe.c
@@ -218,7 +218,21 @@ DisplayBlt(
     )
 {
     UINT8 *VidBuf, *BltBuf, *VidBuf1;
+    UINT32 GopWidth = This->Mode->Info->HorizontalResolution;
+    UINT32 GopHeight = This->Mode->Info->VerticalResolution;
     UINTN i, j;
+
+    if (Width > GopWidth) {
+        DEBUG((DEBUG_ERROR, "Console resolution width (%d) is higher than current GOP resolution width (%d)."
+            " Overriding console resolution width.\n", Width, GopWidth));
+        Width = GopWidth;
+    }
+
+    if (Height > GopHeight) {
+        DEBUG((DEBUG_ERROR, "Console resolution height (%d) is higher than current GOP resolution height (%d)."
+            " Overriding console resolution height.\n", Height, GopHeight));
+        Height = GopHeight;
+    }
 
     switch(BltOperation) {
     case EfiBltVideoFill:

--- a/Pi2BoardPkg/Drivers/DisplayDxe/DisplayDxe.c
+++ b/Pi2BoardPkg/Drivers/DisplayDxe/DisplayDxe.c
@@ -343,7 +343,6 @@ DisplayBlt(
     }
 
 Exit:
-    ASSERT_EFI_ERROR(Status);
     return Status;
 }
 

--- a/Pi2BoardPkg/Pi2BoardPkg.dsc
+++ b/Pi2BoardPkg/Pi2BoardPkg.dsc
@@ -552,8 +552,8 @@
 
 [PcdsPatchableInModule]
   # Console Resolution
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|1024
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|768
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|0
 
 
 ################################################################################

--- a/Pi3BoardPkg/Pi3BoardPkg.dsc
+++ b/Pi3BoardPkg/Pi3BoardPkg.dsc
@@ -550,8 +550,8 @@
 
 [PcdsPatchableInModule]
   # Console Resolution
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|1024
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|768
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|0
 
 
 ################################################################################


### PR DESCRIPTION
 * Check UEFI console resolution against GOP display resolution.
 * Do not specify the console resolution. This way, the maximum GOP display resolution will be used.